### PR TITLE
url动态参数与固定参数冲突

### DIFF
--- a/gee-web/day3-router/gee/router_test.go
+++ b/gee-web/day3-router/gee/router_test.go
@@ -9,7 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/before", nil)
 	r.addRoute("GET", "/hello/:name", nil)
+	r.addRoute("GET", "/hello/after", nil)
+	r.addRoute("GET", "/hello/:name/cool", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
@@ -27,7 +30,19 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+	n, ps := r.getRoute("GET", "/hello/before")
+	if n == nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+	if n.pattern != "/hello/before" {
+		t.Fatal("should match /hello/before")
+	}
+	if len(ps) != 0 {
+		t.Fatal("params should have nothing")
+	}
+	fmt.Printf("matched path: %s, params: %q\n", n.pattern, ps)
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")
@@ -43,6 +58,32 @@ func TestGetRoute(t *testing.T) {
 
 	fmt.Printf("matched path: %s, params['name']: %s\n", n.pattern, ps["name"])
 
+	n, ps = r.getRoute("GET", "/hello/after")
+	if n == nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+	if n.pattern != "/hello/after" {
+		t.Fatal("should match /hello/after")
+	}
+
+	if len(ps) != 0 {
+		t.Fatal("params should have nothing")
+	}
+
+	fmt.Printf("matched path: %s, params: %q\n", n.pattern, ps)
+
+	n, ps = r.getRoute("GET", "/hello/after/cool")
+	if n == nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+	if n.pattern != "/hello/:name/cool" {
+		t.Fatal("should match /hello/:name/cool")
+	}
+
+	if ps["name"] != "after" {
+		t.Fatal("name should be equal to 'after'")
+	}
+	fmt.Printf("matched path: %s, params['name']: %s\n", n.pattern, ps["name"])
 }
 
 func TestGetRoute2(t *testing.T) {
@@ -68,7 +109,7 @@ func TestGetRoutes(t *testing.T) {
 		fmt.Println(i+1, n)
 	}
 
-	if len(nodes) != 5 {
-		t.Fatal("the number of routes shoule be 4")
+	if len(nodes) != 8 {
+		t.Fatal("the number of routes shoule be 8")
 	}
 }

--- a/gee-web/day3-router/gee/trie.go
+++ b/gee-web/day3-router/gee/trie.go
@@ -24,9 +24,13 @@ func (n *node) insert(pattern string, parts []string, height int) {
 
 	part := parts[height]
 	child := n.matchChild(part)
-	if child == nil {
+	if child == nil || (child.isWild && (part[0] != ':' && part[0] != '*')) {
 		child = &node{part: part, isWild: part[0] == ':' || part[0] == '*'}
-		n.children = append(n.children, child)
+		if child.isWild {
+			n.children = append(n.children, child)
+		} else {
+			n.children = append([]*node{child}, n.children...)
+		}
 	}
 	child.insert(pattern, parts, height+1)
 }

--- a/gee-web/day3-router/main.go
+++ b/gee-web/day3-router/main.go
@@ -48,6 +48,10 @@ func main() {
 		c.String(http.StatusOK, "hello %s, you're at %s\n", c.Param("name"), c.Path)
 	})
 
+	r.GET("/hello/cool", func(c *gee.Context) {
+		c.String(http.StatusOK, "fix pattern, you're at %s\n", c.Path)
+	})
+
 	r.GET("/assets/*filepath", func(c *gee.Context) {
 		c.JSON(http.StatusOK, gee.H{"filepath": c.Param("filepath")})
 	})


### PR DESCRIPTION

```golang
// 1
	r.GET("/hello/cool", func(c *gee.Context) {
		c.String(http.StatusOK, "cool cool, you're at %s", c.Path)
	})
	r.GET("/hello/:name", func(c *gee.Context) {
		// expect /hello/geektutu
		c.String(http.StatusOK, "hello %s, you're at %s\n", c.Param("name"), c.Path)
	})
//2 
	r.GET("/hello/:name", func(c *gee.Context) {
		// expect /hello/geektutu
		c.String(http.StatusOK, "hello %s, you're at %s\n", c.Param("name"), c.Path)
	})
	r.GET("/hello/cool", func(c *gee.Context) {
		c.String(http.StatusOK, "cool cool, you're at %s", c.Path)
	})
```

上面两种设置路由的形式会得到不同的效果：
1的方式可以正常访问`/hello/cool`和`/hello/:name`. 
2的形式，当设置`/hello/cool`的时候会将原来的`:name`节点的pattern换成`/hello/cool`, 导致后续`/hello/:name`无法继续正常工作。
修改改的方式就是：
添加cool这个节点的时候新建节点。并且将动态参数的优先级降低(排到数组的后面)。

