### PR TITLE
修正onlyForV2()函数，使测试输出与博客上的结果一致

### DIFF
--- a/gee-web/day5-middleware/main.go
+++ b/gee-web/day5-middleware/main.go
@@ -31,8 +31,7 @@ func onlyForV2() gee.HandlerFunc {
 	return func(c *gee.Context) {
 		// Start timer
 		t := time.Now()
-		// if a server error occurred
-		c.Fail(500, "Internal Server Error")
+		c.Next()
 		// Calculate resolution time
 		log.Printf("[%d] %s in %v for group v2", c.StatusCode, c.Req.RequestURI, time.Since(t))
 	}


### PR DESCRIPTION
在博客“[Go语言动手写Web框架 - Gee第五天](https://geektutu.com/post/gee-day5.html)”中，给出的`onlyForV2()`函数，其中`c.Fail()`函数会导致测试的输出一直是{"message":"Internal Server Error"}，服务端打印的结果也不是[200]。将`c.Fail()`函数改为`c.Next()`函数才能得到跟博客上相同的输出。