### PR TITLE
fix typo: fontend

### DIFF
--- a/gee-cache/day5-multi-nodes/main.go
+++ b/gee-cache/day5-multi-nodes/main.go
@@ -54,7 +54,7 @@ func startAPIServer(apiAddr string, gee *geecache.Group) {
 			w.Write(view.ByteSlice())
 
 		}))
-	log.Println("fontend server is running at", apiAddr)
+	log.Println("frontend server is running at", apiAddr)
 	log.Fatal(http.ListenAndServe(apiAddr[7:], nil))
 
 }

--- a/gee-cache/day6-single-flight/main.go
+++ b/gee-cache/day6-single-flight/main.go
@@ -54,7 +54,7 @@ func startAPIServer(apiAddr string, gee *geecache.Group) {
 			w.Write(view.ByteSlice())
 
 		}))
-	log.Println("fontend server is running at", apiAddr)
+	log.Println("frontend server is running at", apiAddr)
 	log.Fatal(http.ListenAndServe(apiAddr[7:], nil))
 
 }

--- a/gee-cache/day7-proto-buf/main.go
+++ b/gee-cache/day7-proto-buf/main.go
@@ -54,7 +54,7 @@ func startAPIServer(apiAddr string, gee *geecache.Group) {
 			w.Write(view.ByteSlice())
 
 		}))
-	log.Println("fontend server is running at", apiAddr)
+	log.Println("frontend server is running at", apiAddr)
 	log.Fatal(http.ListenAndServe(apiAddr[7:], nil))
 
 }

--- a/gee-cache/doc/geecache-day5.md
+++ b/gee-cache/doc/geecache-day5.md
@@ -263,7 +263,7 @@ func startAPIServer(apiAddr string, gee *geecache.Group) {
 			w.Write(view.ByteSlice())
 
 		}))
-	log.Println("fontend server is running at", apiAddr)
+	log.Println("frontend server is running at", apiAddr)
 	log.Fatal(http.ListenAndServe(apiAddr[7:], nil))
 
 }
@@ -328,7 +328,7 @@ $ ./run.sh
 2020/02/16 21:17:43 geecache is running at http://localhost:8001
 2020/02/16 21:17:43 geecache is running at http://localhost:8002
 2020/02/16 21:17:43 geecache is running at http://localhost:8003
-2020/02/16 21:17:43 fontend server is running at http://localhost:9999
+2020/02/16 21:17:43 frontend server is running at http://localhost:9999
 >>> start test
 2020/02/16 21:17:45 [Server http://localhost:8003] Pick peer http://localhost:8001
 2020/02/16 21:17:45 [Server http://localhost:8003] Pick peer http://localhost:8001


### PR DESCRIPTION
As is suggested by the title: `fontend` -> `frontend`