### PR TITLE
Fix check reply argument type

### DIFF
--- a/gee-rpc/day3-service/service.go
+++ b/gee-rpc/day3-service/service.go
@@ -72,7 +72,7 @@ func (s *service) registerMethods() {
 			continue
 		}
 		argType, replyType := mType.In(1), mType.In(2)
-		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) {
+		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) || !isPtrType(replyType) {
 			continue
 		}
 		s.method[method.Name] = &methodType{
@@ -95,5 +95,10 @@ func (s *service) call(m *methodType, argv, replyv reflect.Value) error {
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {
+
 	return ast.IsExported(t.Name()) || t.PkgPath() == ""
+}
+
+func isPtrType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
 }

--- a/gee-rpc/day4-timeout/service.go
+++ b/gee-rpc/day4-timeout/service.go
@@ -72,7 +72,7 @@ func (s *service) registerMethods() {
 			continue
 		}
 		argType, replyType := mType.In(1), mType.In(2)
-		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) {
+		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) || !isPtrType(replyType) {
 			continue
 		}
 		s.method[method.Name] = &methodType{
@@ -95,5 +95,10 @@ func (s *service) call(m *methodType, argv, replyv reflect.Value) error {
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {
+
 	return ast.IsExported(t.Name()) || t.PkgPath() == ""
+}
+
+func isPtrType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
 }

--- a/gee-rpc/day5-http-debug/service.go
+++ b/gee-rpc/day5-http-debug/service.go
@@ -72,7 +72,7 @@ func (s *service) registerMethods() {
 			continue
 		}
 		argType, replyType := mType.In(1), mType.In(2)
-		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) {
+		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) || !isPtrType(replyType) {
 			continue
 		}
 		s.method[method.Name] = &methodType{
@@ -95,5 +95,10 @@ func (s *service) call(m *methodType, argv, replyv reflect.Value) error {
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {
+
 	return ast.IsExported(t.Name()) || t.PkgPath() == ""
+}
+
+func isPtrType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
 }

--- a/gee-rpc/day6-load-balance/service.go
+++ b/gee-rpc/day6-load-balance/service.go
@@ -72,7 +72,7 @@ func (s *service) registerMethods() {
 			continue
 		}
 		argType, replyType := mType.In(1), mType.In(2)
-		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) {
+		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) || !isPtrType(replyType) {
 			continue
 		}
 		s.method[method.Name] = &methodType{
@@ -95,5 +95,10 @@ func (s *service) call(m *methodType, argv, replyv reflect.Value) error {
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {
+
 	return ast.IsExported(t.Name()) || t.PkgPath() == ""
+}
+
+func isPtrType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
 }

--- a/gee-rpc/day7-registry/service.go
+++ b/gee-rpc/day7-registry/service.go
@@ -72,7 +72,7 @@ func (s *service) registerMethods() {
 			continue
 		}
 		argType, replyType := mType.In(1), mType.In(2)
-		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) {
+		if !isExportedOrBuiltinType(argType) || !isExportedOrBuiltinType(replyType) || !isPtrType(replyType) {
 			continue
 		}
 		s.method[method.Name] = &methodType{
@@ -95,5 +95,10 @@ func (s *service) call(m *methodType, argv, replyv reflect.Value) error {
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {
+
 	return ast.IsExported(t.Name()) || t.PkgPath() == ""
+}
+
+func isPtrType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
 }

--- a/gee-rpc/doc/geerpc-day1.md
+++ b/gee-rpc/doc/geerpc-day1.md
@@ -183,7 +183,7 @@ var DefaultOption = &Option{
 }
 ```
 
-一般来说，涉及协议协商的这部分信息，需要设计固定的字节来传输的。但是为了实现上更简单，GeeRPC 客户端固定采用 JSON 编码 Option，后续的 header 和 body 的编码方式由 Option 中的 CodeType 指定，服务端首先使用 JSON 解码 Option，然后通过 Option 得 CodeType 解码剩余的内容。即报文将以这样的形式发送：
+一般来说，涉及协议协商的这部分信息，需要设计固定的字节来传输的。但是为了实现上更简单，GeeRPC 客户端固定采用 JSON 编码 Option，后续的 header 和 body 的编码方式由 Option 中的 CodeType 指定，服务端首先使用 JSON 解码 Option，然后通过 Option 的 CodeType 解码剩余的内容。即报文将以这样的形式发送：
 
 ```bash
 | Option{MagicNumber: xxx, CodecType: xxx} | Header{ServiceMethod ...} | Body interface{} |


### PR DESCRIPTION
https://github.com/geektutu/7days-golang/blob/cf3644382101dc13e7fd92e8f5c66cabc51bcd3b/gee-rpc/day3-service/service.go#L75
这里只检验了reply Argument是否为导出/内置类型, 没有检验其是否为指针
按照net/rpc的接口, 这是无法Register进入services的
是否应该加上检查是否为指针的操作?