### PR TITLE
fix: misspelled word

### DIFF
--- a/gee-cache/day5-multi-nodes/main.go
+++ b/gee-cache/day5-multi-nodes/main.go
@@ -54,7 +54,7 @@ func startAPIServer(apiAddr string, gee *geecache.Group) {
 			w.Write(view.ByteSlice())
 
 		}))
-	log.Println("fontend server is running at", apiAddr)
+	log.Println("frontend server is running at", apiAddr)
 	log.Fatal(http.ListenAndServe(apiAddr[7:], nil))
 
 }


### PR DESCRIPTION
frontend not fontend