### PR TITLE
fix single-flight ,and add UT description verification

### DIFF
--- a/gee-cache/day6-single-flight/geecache/singleflight/singleflight_test.go
+++ b/gee-cache/day6-single-flight/geecache/singleflight/singleflight_test.go
@@ -1,16 +1,107 @@
 package singleflight
 
 import (
+	"sync"
 	"testing"
+	"time"
 )
 
-func TestDo(t *testing.T) {
-	var g Group
-	v, err := g.Do("key", func() (interface{}, error) {
-		return "bar", nil
-	})
+// Record the fn execution times
+var ExecNum = 0
 
-	if v != "bar" || err != nil {
-		t.Errorf("Do v = %v, error = %v", v, err)
+func TestDoCase1(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	//fn can be executed only one times
+	if ExecNum != 1 {
+		t.Error("singleFlight err")
+	}
+}
+
+func TestDoCase2(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	time.Sleep(time.Second)
+	//One second later, fn will add one more
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	if ExecNum != 2 {
+		t.Error("singleFlight err")
+	}
+}
+
+func TestDoCase3(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+
+			//key1 != key，fn will add one more
+			v, err = g.Do("key1", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar1", nil
+			})
+			if v != "bar1" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+	//fn can be executed only one times
+	if ExecNum != 2 {
+		t.Error("singleFlight err")
 	}
 }

--- a/gee-cache/day7-proto-buf/geecache/singleflight/singleflight_test.go
+++ b/gee-cache/day7-proto-buf/geecache/singleflight/singleflight_test.go
@@ -1,16 +1,107 @@
 package singleflight
 
 import (
+	"sync"
 	"testing"
+	"time"
 )
 
-func TestDo(t *testing.T) {
-	var g Group
-	v, err := g.Do("key", func() (interface{}, error) {
-		return "bar", nil
-	})
+// Record the fn execution times
+var ExecNum = 0
 
-	if v != "bar" || err != nil {
-		t.Errorf("Do v = %v, error = %v", v, err)
+func TestDoCase1(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	//fn can be executed only one times
+	if ExecNum != 1 {
+		t.Error("singleFlight err")
+	}
+}
+
+func TestDoCase2(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	time.Sleep(time.Second)
+	//One second later, fn will add one more
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+
+	if ExecNum != 2 {
+		t.Error("singleFlight err")
+	}
+}
+
+func TestDoCase3(t *testing.T) {
+	var ExecNum = 0
+	var g Group
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			v, err := g.Do("key", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar", nil
+			})
+			if v != "bar" || err != nil {
+				t.Error("Exec Do err")
+			}
+
+			//key1 != key，fn will add one more
+			v, err = g.Do("key1", func() (interface{}, error) {
+				//If call fn once, add it once
+				ExecNum++
+				return "bar1", nil
+			})
+			if v != "bar1" || err != nil {
+				t.Error("Exec Do err")
+			}
+		}()
+	}
+	//fn can be executed only one times
+	if ExecNum != 2 {
+		t.Error("singleFlight err")
 	}
 }


### PR DESCRIPTION
源码single-flight并不能保证fn只执行一次，可以用我提交的单测去跑一下，发现fn的执行次数并不是一次(而且每次运行次数还不确定)，达不到防止缓存击穿的效果。
我的实现思路：map延迟一秒删除，第一个请求更新map，map里面的key全部一秒之后删除，一秒之内的所有请求都从map获取。一秒之后删除map里面一秒钟之前的数据，请求来了再重新更新map，重复如上 步骤。
注：删除数据不一定得一秒钟之后，可以一百毫秒，更具业务可以调整