### PR TITLE
gee-web-fix:修复trie前缀路径树中查找node模糊匹配的bug

### DIFF
--- a/gee-web/day3-router/gee/router_test.go
+++ b/gee-web/day3-router/gee/router_test.go
@@ -9,8 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/bc", nil)
 	r.addRoute("GET", "/hello/:name", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hello/bcb", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
 	return r
@@ -27,7 +29,28 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+
+	n, ps := r.getRoute("GET", "/hello/bcb")
+	if n == nil || n.part != "bcb" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bc")
+	if n == nil || n.part != "bc" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/b/c")
+	if n == nil || n.part != "c" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bvv/c")
+	if n != nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")

--- a/gee-web/day3-router/gee/trie.go
+++ b/gee-web/day3-router/gee/trie.go
@@ -40,9 +40,9 @@ func (n *node) search(parts []string, height int) *node {
 	}
 
 	part := parts[height]
-	children := n.matchChildren(part)
+	child := n.matchChildren(part)
 
-	for _, child := range children {
+	if child != nil {
 		result := child.search(parts, height+1)
 		if result != nil {
 			return result
@@ -61,21 +61,26 @@ func (n *node) travel(list *([]*node)) {
 	}
 }
 
+// Find a matching child node
 func (n *node) matchChild(part string) *node {
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
+		if child.part == part {
 			return child
 		}
 	}
 	return nil
 }
 
-func (n *node) matchChildren(part string) []*node {
-	nodes := make([]*node, 0)
+// Find all eligible child nodes
+func (n *node) matchChildren(part string) *node {
+	//var nodeMatch *node
+	var nodeWild *node
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
-			nodes = append(nodes, child)
+		if child.part == part {
+			return child
+		} else if child.isWild {
+			nodeWild = child
 		}
 	}
-	return nodes
+	return nodeWild
 }

--- a/gee-web/day4-group/gee/router_test.go
+++ b/gee-web/day4-group/gee/router_test.go
@@ -9,8 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/bc", nil)
 	r.addRoute("GET", "/hello/:name", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hello/bcb", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
 	return r
@@ -27,7 +29,28 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+
+	n, ps := r.getRoute("GET", "/hello/bcb")
+	if n == nil || n.part != "bcb" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bc")
+	if n == nil || n.part != "bc" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/b/c")
+	if n == nil || n.part != "c" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bvv/c")
+	if n != nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")

--- a/gee-web/day4-group/gee/trie.go
+++ b/gee-web/day4-group/gee/trie.go
@@ -40,9 +40,9 @@ func (n *node) search(parts []string, height int) *node {
 	}
 
 	part := parts[height]
-	children := n.matchChildren(part)
+	child := n.matchChildren(part)
 
-	for _, child := range children {
+	if child != nil {
 		result := child.search(parts, height+1)
 		if result != nil {
 			return result
@@ -61,21 +61,26 @@ func (n *node) travel(list *([]*node)) {
 	}
 }
 
+// Find a matching child node
 func (n *node) matchChild(part string) *node {
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
+		if child.part == part {
 			return child
 		}
 	}
 	return nil
 }
 
-func (n *node) matchChildren(part string) []*node {
-	nodes := make([]*node, 0)
+// Find all eligible child nodes
+func (n *node) matchChildren(part string) *node {
+	//var nodeMatch *node
+	var nodeWild *node
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
-			nodes = append(nodes, child)
+		if child.part == part {
+			return child
+		} else if child.isWild {
+			nodeWild = child
 		}
 	}
-	return nodes
+	return nodeWild
 }

--- a/gee-web/day5-middleware/gee/router_test.go
+++ b/gee-web/day5-middleware/gee/router_test.go
@@ -9,8 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/bc", nil)
 	r.addRoute("GET", "/hello/:name", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hello/bcb", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
 	return r
@@ -27,7 +29,28 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+
+	n, ps := r.getRoute("GET", "/hello/bcb")
+	if n == nil || n.part != "bcb" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bc")
+	if n == nil || n.part != "bc" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/b/c")
+	if n == nil || n.part != "c" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bvv/c")
+	if n != nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")

--- a/gee-web/day5-middleware/gee/trie.go
+++ b/gee-web/day5-middleware/gee/trie.go
@@ -40,9 +40,9 @@ func (n *node) search(parts []string, height int) *node {
 	}
 
 	part := parts[height]
-	children := n.matchChildren(part)
+	child := n.matchChildren(part)
 
-	for _, child := range children {
+	if child != nil {
 		result := child.search(parts, height+1)
 		if result != nil {
 			return result
@@ -61,21 +61,26 @@ func (n *node) travel(list *([]*node)) {
 	}
 }
 
+// Find a matching child node
 func (n *node) matchChild(part string) *node {
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
+		if child.part == part {
 			return child
 		}
 	}
 	return nil
 }
 
-func (n *node) matchChildren(part string) []*node {
-	nodes := make([]*node, 0)
+// Find all eligible child nodes
+func (n *node) matchChildren(part string) *node {
+	//var nodeMatch *node
+	var nodeWild *node
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
-			nodes = append(nodes, child)
+		if child.part == part {
+			return child
+		} else if child.isWild {
+			nodeWild = child
 		}
 	}
-	return nodes
+	return nodeWild
 }

--- a/gee-web/day6-template/gee/router_test.go
+++ b/gee-web/day6-template/gee/router_test.go
@@ -9,8 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/bc", nil)
 	r.addRoute("GET", "/hello/:name", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hello/bcb", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
 	return r
@@ -27,7 +29,28 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+
+	n, ps := r.getRoute("GET", "/hello/bcb")
+	if n == nil || n.part != "bcb" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bc")
+	if n == nil || n.part != "bc" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/b/c")
+	if n == nil || n.part != "c" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bvv/c")
+	if n != nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")

--- a/gee-web/day6-template/gee/trie.go
+++ b/gee-web/day6-template/gee/trie.go
@@ -40,9 +40,9 @@ func (n *node) search(parts []string, height int) *node {
 	}
 
 	part := parts[height]
-	children := n.matchChildren(part)
+	child := n.matchChildren(part)
 
-	for _, child := range children {
+	if child != nil {
 		result := child.search(parts, height+1)
 		if result != nil {
 			return result
@@ -61,21 +61,26 @@ func (n *node) travel(list *([]*node)) {
 	}
 }
 
+// Find a matching child node
 func (n *node) matchChild(part string) *node {
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
+		if child.part == part {
 			return child
 		}
 	}
 	return nil
 }
 
-func (n *node) matchChildren(part string) []*node {
-	nodes := make([]*node, 0)
+// Find all eligible child nodes
+func (n *node) matchChildren(part string) *node {
+	//var nodeMatch *node
+	var nodeWild *node
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
-			nodes = append(nodes, child)
+		if child.part == part {
+			return child
+		} else if child.isWild {
+			nodeWild = child
 		}
 	}
-	return nodes
+	return nodeWild
 }

--- a/gee-web/day7-panic-recover/gee/router_test.go
+++ b/gee-web/day7-panic-recover/gee/router_test.go
@@ -9,8 +9,10 @@ import (
 func newTestRouter() *router {
 	r := newRouter()
 	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/bc", nil)
 	r.addRoute("GET", "/hello/:name", nil)
 	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hello/bcb", nil)
 	r.addRoute("GET", "/hi/:name", nil)
 	r.addRoute("GET", "/assets/*filepath", nil)
 	return r
@@ -27,7 +29,28 @@ func TestParsePattern(t *testing.T) {
 
 func TestGetRoute(t *testing.T) {
 	r := newTestRouter()
-	n, ps := r.getRoute("GET", "/hello/geektutu")
+
+	n, ps := r.getRoute("GET", "/hello/bcb")
+	if n == nil || n.part != "bcb" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bc")
+	if n == nil || n.part != "bc" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/b/c")
+	if n == nil || n.part != "c" || len(ps) > 0 {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/bvv/c")
+	if n != nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	n, ps = r.getRoute("GET", "/hello/geektutu")
 
 	if n == nil {
 		t.Fatal("nil shouldn't be returned")

--- a/gee-web/day7-panic-recover/gee/trie.go
+++ b/gee-web/day7-panic-recover/gee/trie.go
@@ -40,9 +40,9 @@ func (n *node) search(parts []string, height int) *node {
 	}
 
 	part := parts[height]
-	children := n.matchChildren(part)
+	child := n.matchChildren(part)
 
-	for _, child := range children {
+	if child != nil {
 		result := child.search(parts, height+1)
 		if result != nil {
 			return result
@@ -61,21 +61,26 @@ func (n *node) travel(list *([]*node)) {
 	}
 }
 
+// Find a matching child node
 func (n *node) matchChild(part string) *node {
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
+		if child.part == part {
 			return child
 		}
 	}
 	return nil
 }
 
-func (n *node) matchChildren(part string) []*node {
-	nodes := make([]*node, 0)
+// Find all eligible child nodes
+func (n *node) matchChildren(part string) *node {
+	//var nodeMatch *node
+	var nodeWild *node
 	for _, child := range n.children {
-		if child.part == part || child.isWild {
-			nodes = append(nodes, child)
+		if child.part == part {
+			return child
+		} else if child.isWild {
+			nodeWild = child
 		}
 	}
-	return nodes
+	return nodeWild
 }


### PR DESCRIPTION
## gee-web
### bug
添加`"/hello/:name"`路径后，再添加`"/hello/b/c"`路径，匹配`"/hello/bvv/c"`该路径时，本来不存在的路径会被匹配为`"/hello/b/c"`
### fix
现将 `matchChild`函数改为完全强匹配，在插入路径时，只进行强匹配来找到要添加的节点位置

```
// Find a matching child node
func (n *node) matchChild(part string) *node {
	for _, child := range n.children {
		if child.part == part {
			return child
		}
	}
	return nil
}
```

现将`matchChildren`函数修改，只匹配一个路径，若是有强匹配，则返回强匹配的，没有则返回模糊匹配，在查找路径时先进行强匹配，没有强匹配则尝试返回弱匹配

```
func (n *node) search(parts []string, height int) *node {
	if len(parts) == height || strings.HasPrefix(n.part, "*") {
		if n.pattern == "" {
			return nil
		}
		return n
	}

	part := parts[height]
	child := n.matchChildren(part)

	if child != nil {
		result := child.search(parts, height+1)
		if result != nil {
			return result
		}
	}

	return nil
}


// Find all eligible child nodes
func (n *node) matchChildren(part string) *node {
	//var nodeMatch *node
	var nodeWild *node
	for _, child := range n.children {
		if child.part == part {
			return child
		} else if child.isWild {
			nodeWild = child
		}
	}
	return nodeWild
}
```